### PR TITLE
Add bitcrowd.dev to list of sites

### DIFF
--- a/priv/sites/bitcrowd-dev.txt
+++ b/priv/sites/bitcrowd-dev.txt
@@ -1,0 +1,5 @@
+https://bitcrowd.dev/
+
+bitcrowd
+
+bitcrowd is a software agency from Berlin, Germany. They work with Elixir and the Beam and frequently blog about it and other web development or software engineering related topics.


### PR DESCRIPTION
Hi 👋 

This adds https://bitcrowd.dev to the list of sites. It's the blog of "bitcrowd", a software development agency from Berlin, Germany _(I am working as a developer there)_.

We work with Elixir, so the blog also contains content about Elixir, Phoenix and the Beam.
